### PR TITLE
Fix test when .Library.site has length longer than 1

### DIFF
--- a/tests/test_dotlibPaths.R
+++ b/tests/test_dotlibPaths.R
@@ -1,4 +1,4 @@
-.source("helper/helper.R")
+source("helper/helper.R")
 
 f = get(".libPaths", envir = baseenv())
 expect_same = makeCompareFun(f, backports:::.libPaths)


### PR DESCRIPTION
Hi!

When running a testing suit for your package, I discovered that it fails when `.Library.site` has a length longer than one due to the `%in%` operator returning a vector of length the same as `.Library.site`, which cannot be compared using `&&` operator. I hope adding `any` here fixes it while maintaining test's spirit. 